### PR TITLE
[fix] Dockerfile-spring build fail 이슈 해결

### DIFF
--- a/webtoon-search-back/webtoon-search/docker/Dockerfile-spring
+++ b/webtoon-search-back/webtoon-search/docker/Dockerfile-spring
@@ -2,6 +2,13 @@
 FROM amazoncorretto:21-alpine-jdk AS builder
 WORKDIR /app
 
+# Gradle Wrapper 파일들을 먼저 복사
+COPY gradlew .
+COPY gradle gradle
+
+# Gradle Wrapper에 실행 권한 부여
+RUN chmod +x ./gradlew
+
 # Gradle 빌드 파일 복사 및 의존성 다운로드
 # 이 단계를 분리하여 소스 코드가 변경되어도 의존성 캐시를 재사용할 수 있게 함
 COPY build.gradle settings.gradle ./


### PR DESCRIPTION
## 개요
- github actions 로그 확인 결과 gradlew 스크립트를 찾지 못하는 문제 발견
- 스크립트를 먼저 복사 하고 실행 할 수 있도록 하는 코드 추가
- github actions 빌드 테스트를 진행합니다. 잠시 브랜치 룰을 멈추고 진행합니다

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 코드 중간 통합

