### PR TITLE
[feat] Opensearch client SSL 인증서 검증 실패

### DIFF
--- a/webtoon-search-back/webtoon-search/src/main/java/com/samsamohoh/webtoonsearch/common/TestOpenSearchClientConfig.java
+++ b/webtoon-search-back/webtoon-search/src/main/java/com/samsamohoh/webtoonsearch/common/TestOpenSearchClientConfig.java
@@ -7,6 +7,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.ssl.SSLContextBuilder;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -15,9 +16,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
 /**
  * 로컬 개발 환경을 위한 OpenSearch 설정
  * k3d와 기반 springboot helm으로 구축된 OpenSearch 연결 담당
+ * SSL 검증을 비활성화하여 자체 서명된 인증서를 허용합니다.
  */
 @Configuration
 public class TestOpenSearchClientConfig {
@@ -43,7 +50,12 @@ public class TestOpenSearchClientConfig {
     private String password;
 
     @Bean
-    public OpenSearchClient openSearchClient() {
+    public OpenSearchClient openSearchClient() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        // SSL 컨텍스트 생성 - 모든 인증서를 신뢰하도록 설정
+        SSLContext sslContext = new SSLContextBuilder()
+                .loadTrustMaterial(null, (x509Certificates, s) -> true)
+                .build();
+
         final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY,
                 new UsernamePasswordCredentials(username, password));
@@ -63,6 +75,7 @@ public class TestOpenSearchClientConfig {
                                                 .setConnectTimeout(connectionTimeout)
                                                 .build()
                                 )
+                                .setSSLContext(sslContext)  // SSL 컨텍스트 설정
                                 .setDefaultCredentialsProvider(credentialsProvider)
                                 .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                 )


### PR DESCRIPTION
## 개요
- opensearch 에서 보내는 인증서를 신뢰하는 설정으로 변경
- 개발 환경임을 고려하여 실제 prod 환경에서는 설정 변경 필요

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
